### PR TITLE
Förslag på fix: kartmodal tappar kontroller efter iPhone-zoom (#6)

### DIFF
--- a/ah.html
+++ b/ah.html
@@ -624,23 +624,19 @@ function deleteSavedSagesman(v) { set('7s_sagesman', get('7s_sagesman').filter(x
 // ── Interaktiv karta för STÄLLE ──────────────────────────────────────────────
 let mapInstance = null, mapMarker = null, mapSelectedMgrs = '';
 let mapViewportRestore = null;
-let mapBodyOverflowRestore = '';
 
 function lockViewportForMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport) {
         if (mapViewportRestore === null) mapViewportRestore = viewport.getAttribute('content') || '';
-        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
+        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
     }
-    mapBodyOverflowRestore = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
     window.scrollTo(0, 0);
 }
 
 function restoreViewportAfterMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport && mapViewportRestore !== null) viewport.setAttribute('content', mapViewportRestore);
-    document.body.style.overflow = mapBodyOverflowRestore || '';
 }
 
 function openMapModal() {

--- a/index.html
+++ b/index.html
@@ -648,23 +648,19 @@ let mapSelectedMgrs = '';
 let mapSelectedLat = null;
 let mapSelectedLon = null;
 let mapViewportRestore = null;
-let mapBodyOverflowRestore = '';
 
 function lockViewportForMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport) {
         if (mapViewportRestore === null) mapViewportRestore = viewport.getAttribute('content') || '';
-        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
+        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
     }
-    mapBodyOverflowRestore = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
     window.scrollTo(0, 0);
 }
 
 function restoreViewportAfterMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport && mapViewportRestore !== null) viewport.setAttribute('content', mapViewportRestore);
-    document.body.style.overflow = mapBodyOverflowRestore || '';
 }
 
 function openMapModal() {

--- a/obslosa.html
+++ b/obslosa.html
@@ -667,23 +667,19 @@ document.addEventListener('DOMContentLoaded', () => {
 // ── Interaktiv karta för PLATS ───────────────────────────────────────────────
 let mapInstance = null, mapMarker = null, mapSelectedMgrs = '';
 let mapViewportRestore = null;
-let mapBodyOverflowRestore = '';
 
 function lockViewportForMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport) {
         if (mapViewportRestore === null) mapViewportRestore = viewport.getAttribute('content') || '';
-        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
+        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
     }
-    mapBodyOverflowRestore = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
     window.scrollTo(0, 0);
 }
 
 function restoreViewportAfterMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport && mapViewportRestore !== null) viewport.setAttribute('content', mapViewportRestore);
-    document.body.style.overflow = mapBodyOverflowRestore || '';
 }
 
 function openMapModal() {

--- a/scrim.html
+++ b/scrim.html
@@ -553,23 +553,19 @@ function deleteSavedSagesman(v) { set('7s_sagesman', get('7s_sagesman').filter(x
 // ── Interaktiv karta för STÄLLE ──────────────────────────────────────────────
 let mapInstance = null, mapMarker = null, mapSelectedMgrs = '';
 let mapViewportRestore = null;
-let mapBodyOverflowRestore = '';
 
 function lockViewportForMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport) {
         if (mapViewportRestore === null) mapViewportRestore = viewport.getAttribute('content') || '';
-        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
+        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
     }
-    mapBodyOverflowRestore = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
     window.scrollTo(0, 0);
 }
 
 function restoreViewportAfterMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport && mapViewportRestore !== null) viewport.setAttribute('content', mapViewportRestore);
-    document.body.style.overflow = mapBodyOverflowRestore || '';
 }
 
 function openMapModal() {

--- a/weft.html
+++ b/weft.html
@@ -547,23 +547,19 @@ function deleteSavedSagesman(v) { set('7s_sagesman', get('7s_sagesman').filter(x
 // ── Interaktiv karta för STÄLLE ──────────────────────────────────────────────
 let mapInstance = null, mapMarker = null, mapSelectedMgrs = '';
 let mapViewportRestore = null;
-let mapBodyOverflowRestore = '';
 
 function lockViewportForMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport) {
         if (mapViewportRestore === null) mapViewportRestore = viewport.getAttribute('content') || '';
-        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
+        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
     }
-    mapBodyOverflowRestore = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
     window.scrollTo(0, 0);
 }
 
 function restoreViewportAfterMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport && mapViewportRestore !== null) viewport.setAttribute('content', mapViewportRestore);
-    document.body.style.overflow = mapBodyOverflowRestore || '';
 }
 
 function openMapModal() {

--- a/what.html
+++ b/what.html
@@ -551,23 +551,19 @@ function deleteSavedSagesman(v) { set('7s_sagesman', get('7s_sagesman').filter(x
 // ── Interaktiv karta för STÄLLE ──────────────────────────────────────────────
 let mapInstance = null, mapMarker = null, mapSelectedMgrs = '';
 let mapViewportRestore = null;
-let mapBodyOverflowRestore = '';
 
 function lockViewportForMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport) {
         if (mapViewportRestore === null) mapViewportRestore = viewport.getAttribute('content') || '';
-        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
+        viewport.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0');
     }
-    mapBodyOverflowRestore = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
     window.scrollTo(0, 0);
 }
 
 function restoreViewportAfterMapModal() {
     const viewport = document.querySelector('meta[name="viewport"]');
     if (viewport && mapViewportRestore !== null) viewport.setAttribute('content', mapViewportRestore);
-    document.body.style.overflow = mapBodyOverflowRestore || '';
 }
 
 function openMapModal() {


### PR DESCRIPTION
## Sammanfattning
Detta är ett förslag på fix för issue #6 där iPhone-zoom från formuläret följer med in i kartmodalen och gör att stäng-/bekräfta-kontroller kan hamna utanför synlig vy.

## Ändring
- Temporär viewport-reset när kartmodalen öppnas.
- Återställning av ursprunglig viewport när kartmodalen stängs.
- Applicerat konsekvent i: index.html, what.html, scrim.html, weft.html, h.html, obslosa.html.

## Notering
Ej verifierad på fysisk iPhone ännu (kan inte reproduceras fullständigt på Windows/Firefox).

Refs #6