### PR TITLE
Put manifest.xml in MANIFEST sub-folder

### DIFF
--- a/index.html
+++ b/index.html
@@ -1349,7 +1349,7 @@ function buildDataPackage(cotXml, prefix) {
   </Contents>
 </MissionPackageManifest>`;
     return buildZip([
-        { name: 'manifest.xml', data: manifest },
+        { name: 'MANIFEST/manifest.xml', data: manifest },
         { name: `cot/${prefix.toLowerCase()}-rapport.cot`, data: cotXml }
     ]);
 }


### PR DESCRIPTION
ATAK/WinTAK import fails without correct folder structure in the ZIP.