### PR TITLE
7s hotfix: återställ mörkgrön CSS-variabel-definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,26 @@
     <script type="module" src="pmtiles-layer.js"></script>
     <script src="shared/map-hardat-modal.js" defer></script>
     <style>
+        :root {
+            --bg-primary: #0d1f0d;
+            --bg-secondary: #152815;
+            --bg-card: #1a321a;
+            --bg-input: #0f240f;
+            --border: #2d4a2d;
+            --border-focus: #4a7c4a;
+            --text-primary: #e8f0e8;
+            --text-secondary: #8aaa8a;
+            --text-muted: #5a7a5a;
+            --accent: #4caf50;
+            --accent-hover: #66bb6a;
+            --accent-dim: #1e3d1e;
+            --danger: #c62828;
+            --danger-hover: #e53935;
+            --info: #1565c0;
+            --info-hover: #1976d2;
+            --radius: 8px;
+            --radius-sm: 4px;
+        }
         * { box-sizing: border-box; margin: 0; padding: 0; }
         body {
             font-family: 'Inter', system-ui, sans-serif;


### PR DESCRIPTION
Hotfix för regression från PR #61 / commit 5a66d79 som tog bort :root-blocket. Återställer var(--bg-primary) m.fl. så 7s-sidan får tillbaka mörkgrön layout.